### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# bittorrent-protocol [![travis][travis-image]][travis-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url]
+# bittorrent-protocol
+
+[![travis][travis-image]][travis-url] [![Inline docs][inch-image]][inch-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url]
 
 [travis-image]: https://img.shields.io/travis/feross/bittorrent-protocol.svg?style=flat
 [travis-url]: https://travis-ci.org/feross/bittorrent-protocol
+[inch-image]: https://inch-ci.org/github/feross/bittorrent-protocol.svg?style=flat
+[inch-url]: https://inch-ci.org/github/feross/bittorrent-protocol
 [npm-image]: https://img.shields.io/npm/v/bittorrent-protocol.svg?style=flat
 [npm-url]: https://npmjs.org/package/bittorrent-protocol
 [downloads-image]: https://img.shields.io/npm/dm/bittorrent-protocol.svg?style=flat


### PR DESCRIPTION
Hi there,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/feross/bittorrent-protocol.svg)](http://inch-ci.org/github/feross/bittorrent-protocol)

The badge links to [Inch CI](http://inch-ci.org) and shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs. Besides testing and other coverage, documenting your code is often neglected although it is a very engaging part of Open Source that encourages aspiring developers to jump into the source and see how it all ties together.

So far over 600 **Ruby** projects are sporting these badges to raise awareness for the importance of inline-docs and to show potential contributors that they can expect a certain level of code documentation when they dive into your project's code and motivate them to eventually document their own. I would really like to do the same for the **JavaScript** community and roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [when](https://github.com/cujojs/when)).

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/feross/bittorrent-protocol

What do you think?