### PR TITLE
Use safe-buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ var stream = require('readable-stream')
 var BITFIELD_GROW = 400000
 var KEEP_ALIVE_TIMEOUT = 55000
 
-var MESSAGE_PROTOCOL = new Buffer('\u0013BitTorrent protocol')
-var MESSAGE_KEEP_ALIVE = new Buffer([0x00, 0x00, 0x00, 0x00])
-var MESSAGE_CHOKE = new Buffer([0x00, 0x00, 0x00, 0x01, 0x00])
-var MESSAGE_UNCHOKE = new Buffer([0x00, 0x00, 0x00, 0x01, 0x01])
-var MESSAGE_INTERESTED = new Buffer([0x00, 0x00, 0x00, 0x01, 0x02])
-var MESSAGE_UNINTERESTED = new Buffer([0x00, 0x00, 0x00, 0x01, 0x03])
+var MESSAGE_PROTOCOL = Buffer.from('\u0013BitTorrent protocol')
+var MESSAGE_KEEP_ALIVE = Buffer.from([0x00, 0x00, 0x00, 0x00])
+var MESSAGE_CHOKE = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x00])
+var MESSAGE_UNCHOKE = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01])
+var MESSAGE_INTERESTED = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x02])
+var MESSAGE_UNINTERESTED = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x03])
 
 var MESSAGE_RESERVED = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
 var MESSAGE_PORT = [0x00, 0x00, 0x00, 0x03, 0x09, 0x00, 0x00]
@@ -189,13 +189,13 @@ Wire.prototype.keepAlive = function () {
 Wire.prototype.handshake = function (infoHash, peerId, extensions) {
   var infoHashBuffer, peerIdBuffer
   if (typeof infoHash === 'string') {
-    infoHashBuffer = new Buffer(infoHash, 'hex')
+    infoHashBuffer = Buffer.from(infoHash, 'hex')
   } else {
     infoHashBuffer = infoHash
     infoHash = infoHashBuffer.toString('hex')
   }
   if (typeof peerId === 'string') {
-    peerIdBuffer = new Buffer(peerId, 'hex')
+    peerIdBuffer = Buffer.from(peerId, 'hex')
   } else {
     peerIdBuffer = peerId
     peerId = peerIdBuffer.toString('hex')
@@ -207,7 +207,7 @@ Wire.prototype.handshake = function (infoHash, peerId, extensions) {
 
   this._debug('handshake i=%s p=%s exts=%o', infoHash, peerId, extensions)
 
-  var reserved = new Buffer(MESSAGE_RESERVED)
+  var reserved = Buffer.from(MESSAGE_RESERVED)
 
   // enable extended message
   reserved[5] |= 0x10
@@ -359,7 +359,7 @@ Wire.prototype.cancel = function (index, offset, length) {
  */
 Wire.prototype.port = function (port) {
   this._debug('port %d', port)
-  var message = new Buffer(MESSAGE_PORT)
+  var message = Buffer.from(MESSAGE_PORT)
   message.writeUInt16BE(port, 5)
   this._push(message)
 }
@@ -375,7 +375,7 @@ Wire.prototype.extended = function (ext, obj) {
     ext = this.peerExtendedMapping[ext]
   }
   if (typeof ext === 'number') {
-    var extId = new Buffer([ext])
+    var extId = Buffer.from([ext])
     var buf = Buffer.isBuffer(obj) ? obj : bencode.encode(obj)
 
     this._message(20, [], Buffer.concat([extId, buf]))
@@ -395,7 +395,7 @@ Wire.prototype._read = function () {}
  */
 Wire.prototype._message = function (id, numbers, data) {
   var dataLength = data ? data.length : 0
-  var buffer = new Buffer(5 + 4 * numbers.length)
+  var buffer = Buffer.allocUnsafe(5 + 4 * numbers.length)
 
   buffer.writeUInt32BE(buffer.length + dataLength - 4, 0)
   buffer[4] = id

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "hat": "0.0.3",
     "inherits": "^2.0.1",
     "readable-stream": "^2.0.5",
+    "safe-buffer": "^5.0.1",
     "speedometer": "^1.0.0",
     "xtend": "^4.0.0"
   },

--- a/test/extension.js
+++ b/test/extension.js
@@ -24,10 +24,10 @@ test('Extension.onHandshake', function (t) {
   function TestExtension () {}
   TestExtension.prototype.name = 'test_extension'
   TestExtension.prototype.onHandshake = function (infoHash, peerId, extensions) {
-    t.equal(new Buffer(infoHash, 'hex').length, 20)
-    t.equal(new Buffer(infoHash, 'hex').toString(), '01234567890123456789')
-    t.equal(new Buffer(peerId, 'hex').length, 20)
-    t.equal(new Buffer(peerId, 'hex').toString(), '12345678901234567890')
+    t.equal(Buffer.from(infoHash, 'hex').length, 20)
+    t.equal(Buffer.from(infoHash, 'hex').toString(), '01234567890123456789')
+    t.equal(Buffer.from(peerId, 'hex').length, 20)
+    t.equal(Buffer.from(peerId, 'hex').toString(), '12345678901234567890')
   }
 
   var wire = new Protocol()
@@ -36,7 +36,7 @@ test('Extension.onHandshake', function (t) {
 
   wire.use(TestExtension)
 
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 })
 
 test('Extension.onExtendedHandshake', function (t) {
@@ -86,6 +86,6 @@ test('Extension.onMessage', function (t) {
   wire.handshake('3031323334353637383930313233343536373839', '3132333435363738393031323334353637383930')
 
   wire.once('extended', function () {
-    wire.extended('test_extension', new Buffer('hello world!'))
+    wire.extended('test_extension', Buffer.from('hello world!'))
   })
 })

--- a/test/no-timeout.js
+++ b/test/no-timeout.js
@@ -8,7 +8,7 @@ test('No timeout when peer is good', function (t) {
   wire.on('error', function (err) { t.fail(err) })
   wire.pipe(wire)
   wire.setTimeout(1000)
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 
   wire.on('unchoke', function () {
     var requests = 0
@@ -30,7 +30,7 @@ test('No timeout when peer is good', function (t) {
   })
 
   wire.on('request', function (i, offset, length, callback) {
-    callback(null, new Buffer('hello world'))
+    callback(null, Buffer.from('hello world'))
   })
 
   // there should never be a timeout

--- a/test/protocol.js
+++ b/test/protocol.js
@@ -9,13 +9,13 @@ test('Handshake', function (t) {
   wire.pipe(wire)
 
   wire.on('handshake', function (infoHash, peerId) {
-    t.equal(new Buffer(infoHash, 'hex').length, 20)
-    t.equal(new Buffer(infoHash, 'hex').toString(), '01234567890123456789')
-    t.equal(new Buffer(peerId, 'hex').length, 20)
-    t.equal(new Buffer(peerId, 'hex').toString(), '12345678901234567890')
+    t.equal(Buffer.from(infoHash, 'hex').length, 20)
+    t.equal(Buffer.from(infoHash, 'hex').toString(), '01234567890123456789')
+    t.equal(Buffer.from(peerId, 'hex').length, 20)
+    t.equal(Buffer.from(peerId, 'hex').toString(), '12345678901234567890')
   })
 
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 })
 
 test('Handshake (with string args)', function (t) {
@@ -26,10 +26,10 @@ test('Handshake (with string args)', function (t) {
   wire.pipe(wire)
 
   wire.on('handshake', function (infoHash, peerId) {
-    t.equal(new Buffer(infoHash, 'hex').length, 20)
-    t.equal(new Buffer(infoHash, 'hex').toString(), '01234567890123456789')
-    t.equal(new Buffer(peerId, 'hex').length, 20)
-    t.equal(new Buffer(peerId, 'hex').toString(), '12345678901234567890')
+    t.equal(Buffer.from(infoHash, 'hex').length, 20)
+    t.equal(Buffer.from(infoHash, 'hex').toString(), '01234567890123456789')
+    t.equal(Buffer.from(peerId, 'hex').length, 20)
+    t.equal(Buffer.from(peerId, 'hex').toString(), '12345678901234567890')
   })
 
   wire.handshake('3031323334353637383930313233343536373839', '3132333435363738393031323334353637383930')
@@ -46,8 +46,8 @@ test('Asynchronous handshake + extended handshake', function (t) {
 
   wire1.on('handshake', function (infoHash, peerId, extensions) {
     eventLog.push('w1 hs')
-    t.equal(new Buffer(infoHash, 'hex').toString(), '01234567890123456789')
-    t.equal(new Buffer(peerId, 'hex').toString(), '12345678901234567890')
+    t.equal(Buffer.from(infoHash, 'hex').toString(), '01234567890123456789')
+    t.equal(Buffer.from(peerId, 'hex').toString(), '12345678901234567890')
     t.equal(extensions.extended, true)
   })
   wire1.on('extended', function (ext, obj) {
@@ -63,8 +63,8 @@ test('Asynchronous handshake + extended handshake', function (t) {
 
   wire2.on('handshake', function (infoHash, peerId, extensions) {
     eventLog.push('w2 hs')
-    t.equal(new Buffer(infoHash, 'hex').toString(), '01234567890123456789')
-    t.equal(new Buffer(peerId, 'hex').toString(), '12345678901234567890')
+    t.equal(Buffer.from(infoHash, 'hex').toString(), '01234567890123456789')
+    t.equal(Buffer.from(peerId, 'hex').toString(), '12345678901234567890')
     t.equal(extensions.extended, true)
 
     // Respond asynchronously
@@ -88,7 +88,7 @@ test('Unchoke', function (t) {
   var wire = new Protocol()
   wire.on('error', function (err) { t.fail(err) })
   wire.pipe(wire)
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 
   t.ok(wire.amChoking)
   t.ok(wire.peerChoking)
@@ -107,7 +107,7 @@ test('Interested', function (t) {
   var wire = new Protocol()
   wire.on('error', function (err) { t.fail(err) })
   wire.pipe(wire)
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 
   t.ok(!wire.amInterested)
   t.ok(!wire.peerInterested)
@@ -126,7 +126,7 @@ test('Request a piece', function (t) {
   var wire = new Protocol()
   wire.on('error', function (err) { t.fail(err) })
   wire.pipe(wire)
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 
   t.equal(wire.requests.length, 0)
   t.equal(wire.peerRequests.length, 0)
@@ -137,7 +137,7 @@ test('Request a piece', function (t) {
     t.equal(i, 0)
     t.equal(offset, 1)
     t.equal(length, 11)
-    callback(null, new Buffer('hello world'))
+    callback(null, Buffer.from('hello world'))
   })
 
   wire.once('unchoke', function () {

--- a/test/state-change-on-end.js
+++ b/test/state-change-on-end.js
@@ -8,7 +8,7 @@ test('State changes correctly on wire \'end\'', function (t) {
   wire.on('error', function (err) { t.fail(err) })
   wire.pipe(wire)
 
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 
   t.ok(wire.amChoking)
   t.ok(wire.peerChoking)

--- a/test/timeout-destroy.js
+++ b/test/timeout-destroy.js
@@ -10,7 +10,7 @@ test('Timeout and destroy when peer does not respond', function (t) {
   wire.on('error', function (err) { t.fail(err) })
   wire.pipe(wire)
   wire.setTimeout(1000)
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 
   wire.on('unchoke', function () {
     var requests = 0

--- a/test/timeout.js
+++ b/test/timeout.js
@@ -10,7 +10,7 @@ test('Timeout when peer does not respond', function (t) {
   wire.on('error', function (err) { t.fail(err) })
   wire.pipe(wire)
   wire.setTimeout(1000)
-  wire.handshake(new Buffer('01234567890123456789'), new Buffer('12345678901234567890'))
+  wire.handshake(Buffer.from('01234567890123456789'), Buffer.from('12345678901234567890'))
 
   wire.on('unchoke', function () {
     var requests = 0


### PR DESCRIPTION
Use the new Buffer APIs from Node v6 for added security. For example,
`Buffer.from()` will throw if passed a number, unlike `Buffer()` which
allocated UNINITIALIZED memory in that case.

Use the `safe-buffer` package for compatibility with previous versions
of Node.js, including v4.x, v0.12, and v0.10.

https://github.com/feross/safe-buffer